### PR TITLE
added extern declaration to commonb.h allow compilation with gcc 10 on raspbian…

### DIFF
--- a/source/common.h
+++ b/source/common.h
@@ -30,17 +30,18 @@ SOFTWARE.
 #define I2C          42
 #define PWM          43
 
-int gpio_mode;
+extern int gpio_mode;
 #define MAXPINCOUNT 40
-const int pin_to_gpio_rev1[MAXPINCOUNT+1];
-const int pin_to_gpio_rev2[MAXPINCOUNT+1];
-const int pin_to_gpio_rev3[MAXPINCOUNT+1];
-const int (*pin_to_gpio)[MAXPINCOUNT+1];
+
+extern const int pin_to_gpio_rev1[MAXPINCOUNT+1];
+extern const int pin_to_gpio_rev2[MAXPINCOUNT+1];
+extern const int pin_to_gpio_rev3[MAXPINCOUNT+1];
+extern const int (*pin_to_gpio)[MAXPINCOUNT+1];
 #define MAXGPIOCOUNT 255
-int gpio_direction[MAXGPIOCOUNT+1];
-rpi_info rpiinfo;
-int setup_error;
-int module_setup;
+extern int gpio_direction[MAXGPIOCOUNT+1];
+extern rpi_info rpiinfo;
+extern int setup_error;
+extern int module_setup;
 
 int check_gpio_priv(void);
 int get_gpio_number(int channel, unsigned int *gpio);


### PR DESCRIPTION
I couldn't get the code to compile on the M5 with raspbian 11 due to duplicate declaration errors. This fixed it.